### PR TITLE
Remove hardcoded response body background due to problems with using a dark look and feel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.javierllorente</groupId>
     <artifactId>netbeans-rest-client</artifactId>
-    <version>0.3</version>
+    <version>0.3.1</version>
     <name>REST Client</name>
     <description>A REST client for NetBeans</description>
     <packaging>nbm</packaging>

--- a/src/main/java/com/javierllorente/netbeans/rest/client/ui/ResponsePanel.java
+++ b/src/main/java/com/javierllorente/netbeans/rest/client/ui/ResponsePanel.java
@@ -44,7 +44,6 @@ public class ResponsePanel extends JPanel {
         
         responsePane = new JEditorPane();
         responsePane.setEditable(false);
-        responsePane.setBackground(new java.awt.Color(255, 255, 255));
         responsePane.setCursor(new java.awt.Cursor(java.awt.Cursor.TEXT_CURSOR));
         JScrollPane responseScrollPane = new JScrollPane();
         responseScrollPane.setViewportView(responsePane);


### PR DESCRIPTION
While using your plugin in FlatLaF dark mode, the reponse body has a white background which looks odd. This happens because of the hardcoded white background in the ResponsePanel.java which I removed to let the panel decide the color from look and feel.


Before:
<img width="841" alt="image" src="https://user-images.githubusercontent.com/795658/197594572-7140d4a6-166d-40df-8190-dc6c7d6a35b4.png">

After:
<img width="699" alt="image" src="https://user-images.githubusercontent.com/795658/197594823-e47ad66d-2250-4269-a866-7bcfc25de7fa.png">
