### PR TITLE
Add editorUI instead of plain JEditorPane to have linenumbers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.javierllorente</groupId>
     <artifactId>netbeans-rest-client</artifactId>
-    <version>0.5.3</version>
+    <version>0.6.0</version>
     <name>REST Client</name>
     <description>A REST client for NetBeans</description>
     <packaging>nbm</packaging>
@@ -70,8 +70,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/javierllorente/netbeans/rest/client/ui/LineNumberComponent.java
+++ b/src/main/java/com/javierllorente/netbeans/rest/client/ui/LineNumberComponent.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 Christian Lenz <christian.lenz@gmx.net>.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.javierllorente.netbeans.rest.client.ui;
 
 import java.awt.*;
@@ -5,8 +20,10 @@ import java.awt.geom.Rectangle2D;
 import javax.swing.*;
 import javax.swing.text.*;
 
-// HINT: Zoom not resizing linenumbers
-// HINT: Fixed linenumbers width
+/**
+ *
+ * @author Christian Lenz <christian.lenz@gmx.net>
+ */
 public class LineNumberComponent extends JComponent {
 
     private final JTextComponent textComponent;
@@ -24,13 +41,19 @@ public class LineNumberComponent extends JComponent {
     @Override
     protected void paintComponent(Graphics g) {
         super.paintComponent(g);
-        g.setColor(Color.GRAY);
+
+        Graphics2D g2d = (Graphics2D) g;
+
+        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
+
+        g2d.setColor(Color.GRAY);
 
         try {
             JViewport viewport = (JViewport) SwingUtilities.getAncestorOfClass(JViewport.class, textComponent);
             if (viewport != null) {
                 Point viewPosition = viewport.getViewPosition();
-                Rectangle clip = g.getClipBounds();
+                Rectangle clip = g2d.getClipBounds();
 
                 int startOffset = textComponent.viewToModel2D(new Point(0, clip.y + viewPosition.y));
                 int endOffset = textComponent.viewToModel2D(new Point(0, clip.y + clip.height + viewPosition.y));
@@ -41,7 +64,7 @@ public class LineNumberComponent extends JComponent {
                 int startLine = root.getElementIndex(startOffset);
                 int endLine = root.getElementIndex(endOffset);
 
-                FontMetrics fontMetrics = g.getFontMetrics();
+                FontMetrics fontMetrics = g2d.getFontMetrics();
                 int fontAscent = fontMetrics.getAscent();
 
                 for (int line = startLine; line <= endLine; line++) {
@@ -51,7 +74,7 @@ public class LineNumberComponent extends JComponent {
                     if (r != null && r.getY() - viewPosition.y + r.getHeight() > clip.y) {
                         String lineNumber = String.valueOf(line + 1);
                         int y = (int) Math.round(r.getY() - viewPosition.y + fontAscent);
-                        g.drawString(lineNumber, getWidth() - fontMetrics.stringWidth(lineNumber) - 5, y);
+                        g2d.drawString(lineNumber, getWidth() - fontMetrics.stringWidth(lineNumber) - 5, y);
                     }
                 }
             }

--- a/src/main/java/com/javierllorente/netbeans/rest/client/ui/LineNumberComponent.java
+++ b/src/main/java/com/javierllorente/netbeans/rest/client/ui/LineNumberComponent.java
@@ -1,0 +1,78 @@
+package com.javierllorente.netbeans.rest.client.ui;
+
+import java.awt.*;
+import java.awt.geom.Rectangle2D;
+import javax.swing.*;
+import javax.swing.text.*;
+
+// HINT: Zoom not resizing linenumbers
+// HINT: Fixed linenumbers width
+public class LineNumberComponent extends JComponent {
+
+    private final JTextComponent textComponent;
+    private int lastDigits = 0;
+
+    public LineNumberComponent(JTextComponent textComponent) {
+        this.textComponent = textComponent;
+        Font font = textComponent.getFont();
+        setFont(font);
+        setPreferredSize(new Dimension(40, textComponent.getHeight()));
+
+//        adjustWidth();
+    }
+
+    @Override
+    protected void paintComponent(Graphics g) {
+        super.paintComponent(g);
+        g.setColor(Color.GRAY);
+
+        try {
+            JViewport viewport = (JViewport) SwingUtilities.getAncestorOfClass(JViewport.class, textComponent);
+            if (viewport != null) {
+                Point viewPosition = viewport.getViewPosition();
+                Rectangle clip = g.getClipBounds();
+
+                int startOffset = textComponent.viewToModel2D(new Point(0, clip.y + viewPosition.y));
+                int endOffset = textComponent.viewToModel2D(new Point(0, clip.y + clip.height + viewPosition.y));
+
+                Document doc = textComponent.getDocument();
+                Element root = doc.getDefaultRootElement();
+
+                int startLine = root.getElementIndex(startOffset);
+                int endLine = root.getElementIndex(endOffset);
+
+                FontMetrics fontMetrics = g.getFontMetrics();
+                int fontAscent = fontMetrics.getAscent();
+
+                for (int line = startLine; line <= endLine; line++) {
+                    int lineStartOffset = root.getElement(line).getStartOffset();
+                    Rectangle2D r = textComponent.modelToView2D(lineStartOffset);
+
+                    if (r != null && r.getY() - viewPosition.y + r.getHeight() > clip.y) {
+                        String lineNumber = String.valueOf(line + 1);
+                        int y = (int) Math.round(r.getY() - viewPosition.y + fontAscent);
+                        g.drawString(lineNumber, getWidth() - fontMetrics.stringWidth(lineNumber) - 5, y);
+                    }
+                }
+            }
+        } catch (BadLocationException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void adjustWidth() {
+        int lines = getLineCount();
+        int digits = Math.max(String.valueOf(lines).length(), 1);
+
+        if (digits != lastDigits) {
+            int width = getFontMetrics(getFont()).stringWidth("0") * digits + 16;
+            setPreferredSize(new Dimension(width, getHeight()));
+            lastDigits = digits;
+            revalidate();
+        }
+    }
+
+    private int getLineCount() {
+        return textComponent.getDocument().getDefaultRootElement().getElementCount();
+    }
+}

--- a/src/main/java/com/javierllorente/netbeans/rest/client/ui/ResponsePanel.java
+++ b/src/main/java/com/javierllorente/netbeans/rest/client/ui/ResponsePanel.java
@@ -15,8 +15,8 @@
  */
 package com.javierllorente.netbeans.rest.client.ui;
 
-import com.javierllorente.netbeans.rest.client.editor.RestMediaType;
 import com.javierllorente.netbeans.rest.client.Utils;
+import com.javierllorente.netbeans.rest.client.editor.RestMediaType;
 import jakarta.json.Json;
 import jakarta.json.JsonReader;
 import jakarta.ws.rs.core.MediaType;
@@ -45,42 +45,49 @@ public class ResponsePanel extends JPanel {
     private final JToggleButton prettyButton;
     private final TablePanel responseHeadersTable;
     private final StatusLabel statusLabel;
-    private String mimePath;
+    private final LineNumberComponent lineNumberComponent;
+    private String mimePath = MediaType.TEXT_PLAIN;
     private String response;
 
-    public ResponsePanel() {        
+    public ResponsePanel() {
         super(new BorderLayout());
-        
+
         responseTabbedPane = new JTabbedPane();
         responseTabbedPane.setPreferredSize(new Dimension(705, 150));
-        
+
         responseEditorPane = new JEditorPane();
         responseEditorPane.setEditable(false);
         responseEditorPane.setCursor(new java.awt.Cursor(java.awt.Cursor.TEXT_CURSOR));
+        responseEditorPane.setAutoscrolls(true);
         JScrollPane responseScrollPane = new JScrollPane();
         responseScrollPane.setViewportView(responseEditorPane);
-       
+
         JPanel topPanel = new JPanel();
         topPanel.setLayout(new FlowLayout(FlowLayout.LEFT));
-        
+
         prettyButton = new JToggleButton("Pretty", true);
         JToggleButton rawButton = new JToggleButton("Raw", false);
         prettyButton.addItemListener((ie) -> {
             showResponse();
         });
-        
+
         ButtonGroup formatGroup = new ButtonGroup();
         formatGroup.add(prettyButton);
         formatGroup.add(rawButton);
         topPanel.add(prettyButton);
         topPanel.add(rawButton);
-        
+
+        responseScrollPane = new JScrollPane();
+
         JPanel responseBodyPanel = new JPanel();
         responseBodyPanel.setLayout(new BorderLayout());
         responseBodyPanel.add(topPanel, BorderLayout.NORTH);
         responseBodyPanel.add(responseScrollPane, BorderLayout.CENTER);
-        
-        responseTabbedPane.addTab("Body", responseBodyPanel);        
+
+        responseEditorPane.setEditorKit(CloneableEditorSupport.getEditorKit(mimePath));
+        responseScrollPane.setViewportView(responseEditorPane);
+
+        responseTabbedPane.addTab("Body", responseBodyPanel);
         responseHeadersTable = new TablePanel();
         responseHeadersTable.setReadOnly();
         responseTabbedPane.addTab("Headers", responseHeadersTable);
@@ -88,26 +95,31 @@ public class ResponsePanel extends JPanel {
         statusLabel = new StatusLabel();
         JLayer<JComponent> decoratedPane = new JLayer<>(responseTabbedPane, statusLabel);
         add(decoratedPane);
-        
-        mimePath = MediaType.TEXT_PLAIN;
+
+        lineNumberComponent = new LineNumberComponent(responseEditorPane);
+
+        responseScrollPane.getVerticalScrollBar().addAdjustmentListener(e -> lineNumberComponent.repaint());
+        responseScrollPane.getHorizontalScrollBar().addAdjustmentListener(e -> lineNumberComponent.repaint());
+        responseScrollPane.setRowHeaderView(lineNumberComponent);
+
     }
-    
+
     public void setContentType(String contentType) {
         if (contentType.startsWith(MediaType.APPLICATION_XML)) {
             mimePath = RestMediaType.XML;
-        } else if (contentType.startsWith(MediaType.APPLICATION_JSON) 
-                || contentType.startsWith("application/javascript")) {
+        } else if (contentType.startsWith(MediaType.APPLICATION_JSON)
+            || contentType.startsWith("application/javascript")) {
             mimePath = RestMediaType.JSON;
         } else if (contentType.startsWith(MediaType.TEXT_HTML)) {
             mimePath = MediaType.TEXT_HTML;
         }
         responseEditorPane.setEditorKit(CloneableEditorSupport.getEditorKit(mimePath));
     }
-    
+
     public void setResponse(String response) {
         this.response = response;
     }
-    
+
     private String formatResponse() {
         String prettyOrNotResponse = response;
         if (prettyButton.isSelected()) {
@@ -116,46 +128,49 @@ public class ResponsePanel extends JPanel {
                     try (JsonReader jsonReader = Json.createReader(new StringReader(prettyOrNotResponse))) {
                         prettyOrNotResponse = Utils.jsonPrettyFormat(jsonReader.read());
                     }
-                break;
+                    break;
                 case RestMediaType.XML:
                     prettyOrNotResponse = Utils.xmlPrettyFormat(prettyOrNotResponse);
                     break;
             }
         }
+
+        lineNumberComponent.repaint();
+
         return prettyOrNotResponse;
     }
-    
+
     public void showResponse() {
         String prettyOrNotResponse = formatResponse();
         responseEditorPane.setText(prettyOrNotResponse);
         responseEditorPane.setCaretPosition(0);
     }
-    
+
     public void clearResponse() {
         responseEditorPane.setText("");
         responseEditorPane.setCaretPosition(0);
     }
-    
+
     public void addHeader(String key, String value) {
         responseHeadersTable.addRow(key, value);
     }
-    
+
     public void clearHeadersTable() {
         responseHeadersTable.removeAllRows();
     }
-    
+
     public void setStatus(String status) {
         statusLabel.setText(status);
         revalidate();
         repaint();
     }
-    
+
     public void clearStatus() {
         statusLabel.setText("");
         revalidate();
         repaint();
     }
-    
+
     public void clear() {
         clearResponse();
         clearStatus();


### PR DESCRIPTION
I added the editorUI instead of plain JEditorPane. We have some more options like showing line numbers and formatting.
Unfortunately we still have some other things to fix:

* Some sidebar actions are available, which are not needed (Show linenumbers, show bookmarks)
* Some editor actions for specific mimetype are there (navigate, insert code, etc.)
* We have the breadCrumb bar below the editor, which is also not needed
* Sidebar (Linenumbers) and Breadcrumb bar are synced with the normal editor. If we deactivate the linenumbers for any editor, or inside our editor it is synced with all other editors same for showing breadcrumbs

I dunno whether we can hack those things for example add a new popupMenu with couple of actions (copy, format, etc.). I tried this but it didn't work out.

So at the end it is up to use, to merge this or we should just add simple line numbers to JEditorPane as the editor already does.

Also I fixed a JSON parsing exception.