### PR TITLE
Check mediaType is set to prevent NPE for 401, 404, etc.

### DIFF
--- a/src/main/java/com/javierllorente/netbeans/rest/client/RestClient.java
+++ b/src/main/java/com/javierllorente/netbeans/rest/client/RestClient.java
@@ -157,7 +157,7 @@ public class RestClient {
             responseHeaders = response.getHeaders();
             response.bufferEntity();
 
-            if (response.getMediaType().equals(MediaType.APPLICATION_JSON_TYPE)) {
+            if (response.getMediaType() != null && response.getMediaType().equals(MediaType.APPLICATION_JSON_TYPE)) {
                 JsonObject jsonObject = response.readEntity(JsonObject.class);
                 str = Utils.jsonPrettyFormat(jsonObject);
             } else {


### PR DESCRIPTION
When the response is 401 or 404 (Maybe others too like 500 etc.) then the mediaType is not set and it raises a NullPointerException. Here I check against not null othewise body will be empty which is same behaviour as for postman.