### PR TITLE
#25 - Fix Module name. Set NetBeans Relase API Version to minimum NB 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <url>https://github.com/javierllorente/netbeans-rest-client</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <netbeans.version>RELEASE240</netbeans.version>
+        <netbeans.version>RELEASE170</netbeans.version>
     </properties>
     <developers>
         <developer>

--- a/src/main/resources/com/javierllorente/netbeans/rest/client/Bundle.properties
+++ b/src/main/resources/com/javierllorente/netbeans/rest/client/Bundle.properties
@@ -1,4 +1,4 @@
-OpenIDE-Module-Name=HTTP Language Editor Support
+OpenIDE-Module-Name=REST Client
 
 Editors/text/x-http=HTTP File
 


### PR DESCRIPTION
This PR fixes #25 with a wrong module name and add a minimum NB API version to 17.